### PR TITLE
server tests: Update the test NAME of multihost_migration_mix

### DIFF
--- a/multihost_migration_mix/control.srv
+++ b/multihost_migration_mix/control.srv
@@ -1,6 +1,6 @@
 AUTHOR = "ypu@redhat.com (Yiqiao Pu)"
 TIME = "MEDIUM"
-NAME = "Multi_host migration"
+NAME = "Multi_host migration with other cases"
 TEST_CATEGORY = "Virtualization"
 TEST_CLASS = 'Multihost Migration'
 TEST_TYPE = "Server"


### PR DESCRIPTION
The original NAME for this test is duplicated with multihost_migration.
And this will cause problem when we install the autotest server.

Signed-off-by: Yiqiao Pu ypu@redhat.com
