### PR TITLE
autotest-server-tests: Remove unused imports

### DIFF
--- a/iperf/iperf.py
+++ b/iperf/iperf.py
@@ -1,5 +1,4 @@
 from autotest.server import autotest_remote, hosts, subcommand, test
-from autotest.server import utils
 
 
 class iperf(test.test):

--- a/multihost_migration/multihost_migration.py
+++ b/multihost_migration/multihost_migration.py
@@ -1,13 +1,12 @@
 import sys
 import os
-import commands
 import logging
 import random
 import shutil
 from autotest.server import autotest_remote, hosts, subcommand, test
 from autotest.client.shared import error
 # pylint: disable=E0611
-from autotest.client.tests.virt.virttest import utils_misc, cartesian_config
+from autotest.client.tests.virt.virttest import cartesian_config
 # pylint: disable=E0611
 from autotest.client.tests.virt.virttest import bootstrap, utils_params
 from autotest.client.tests.virt.virttest import data_dir, asset

--- a/multihost_migration_mix/multihost_migration_mix.py
+++ b/multihost_migration_mix/multihost_migration_mix.py
@@ -1,13 +1,12 @@
 import sys
 import os
-import commands
 import logging
 import random
 import shutil
 from autotest.server import autotest_remote, hosts, subcommand, test
 from autotest.client.shared import error
 # pylint: disable=E0611
-from autotest.client.tests.virt.virttest import utils_misc, cartesian_config
+from autotest.client.tests.virt.virttest import cartesian_config
 # pylint: disable=E0611
 from autotest.client.tests.virt.virttest import bootstrap, utils_params
 from autotest.client.tests.virt.virttest import data_dir, asset

--- a/netperf2/netperf2.py
+++ b/netperf2/netperf2.py
@@ -1,5 +1,4 @@
 from autotest.server import autotest_remote, hosts, subcommand, test
-from autotest.server import utils
 
 
 class netperf2(test.test):

--- a/netpipe/netpipe.py
+++ b/netpipe/netpipe.py
@@ -1,5 +1,4 @@
 from autotest.server import autotest_remote, hosts, subcommand, test
-from autotest.server import utils
 
 
 class netpipe(test.test):

--- a/reinstall/reinstall.py
+++ b/reinstall/reinstall.py
@@ -1,4 +1,3 @@
-import time
 from autotest.server import test
 from autotest.client.shared import error
 

--- a/sleeptest/sleeptest.py
+++ b/sleeptest/sleeptest.py
@@ -1,4 +1,3 @@
-import time
 from autotest.server import test
 
 


### PR DESCRIPTION
Found by the latest inspektor 0.2.0

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>